### PR TITLE
fix: 适配 NEU 统一认证新 RSA 登录并为网络请求增加超时

### DIFF
--- a/ipgw/core/api/SSO.py
+++ b/ipgw/core/api/SSO.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup, Tag
 from requests import Session
 
 from .SSO_error import BackendError, UnionAuthError, UnknownPageError
+from .sso_rsa import extract_login_page_rsa_public_key, rsa_encrypt_username_password
 
 ua = '''Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'''
 # target = '''https://pass.neu.edu.cn/tpass/login?service=https%3A%2F%2Fipgw.neu.edu.cn%2Fsrun_cas.php%3Fac_id%3D1'''
@@ -23,6 +24,7 @@ class SSOPage(TypedDict):
     form_lt_string: str
     form_execution: str
     form_destination: str
+    rsa_public_key: str
 
 
 # 准备一个SSO内容，里面有
@@ -32,7 +34,8 @@ def SSO_prepare(session: Session) -> SSOPage:
     sso_form_data = {
         "form_lt_string": form.find("input", {'id': 'lt'}).attrs["value"],
         "form_destination": form.attrs['action'],
-        "form_execution": form.find("input", {'name': 'execution'}).attrs["value"]
+        "form_execution": form.find("input", {'name': 'execution'}).attrs["value"],
+        "rsa_public_key": extract_login_page_rsa_public_key(session, page_soup)
     }
     logging.debug(f"sso_form_data: {sso_form_data}")
     return sso_form_data
@@ -41,7 +44,7 @@ def SSO_prepare(session: Session) -> SSOPage:
 # 请求SSO和认证SSO两个操作合并到一个API接口中，直接操作。返回一个SSO ticket。这个函数会触发异常
 def SSO_login(session: Session, page: SSOPage, username, password, ac_id) -> str:
     form_data = {
-        'rsa': username + password + page['form_lt_string'],
+        'rsa': rsa_encrypt_username_password(username, password, page["rsa_public_key"]),
         'ul': len(username),
         'pl': len(password),
         'lt': page['form_lt_string'],

--- a/ipgw/core/api/sso_rsa.py
+++ b/ipgw/core/api/sso_rsa.py
@@ -1,0 +1,98 @@
+import re
+from base64 import b64decode
+from base64 import b64encode
+from secrets import token_bytes
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+from requests import Session
+
+from .SSO_error import BackendError
+
+RSA_PADDING_OVERHEAD = 11
+
+
+def extract_login_page_rsa_public_key(session: Session, page_soup: BeautifulSoup) -> str:
+    login_js_src = None
+    for script_tag in page_soup.find_all("script", src=True):
+        script_src = script_tag.attrs.get("src", "")
+        if "login_neu.js" in script_src:
+            login_js_src = script_src
+            break
+    if not login_js_src:
+        raise BackendError("cannot find login_neu.js from SSO login page")
+
+    login_js_url = urljoin("https://pass.neu.edu.cn", login_js_src)
+    login_js_text = session.get(login_js_url).text
+    public_key_match = re.search(r'publicKeyStr\s*=\s*"([^"]+)"', login_js_text)
+    if not public_key_match:
+        raise BackendError("cannot extract publicKeyStr from login_neu.js")
+    return public_key_match.group(1)
+
+
+def _read_der_tlv(der_bytes: bytes, offset: int):
+    if offset >= len(der_bytes):
+        raise ValueError("invalid DER: unexpected end of data")
+    tag = der_bytes[offset]
+    offset += 1
+    if offset >= len(der_bytes):
+        raise ValueError("invalid DER: missing length")
+    first_length = der_bytes[offset]
+    offset += 1
+    if first_length & 0x80:
+        length_bytes_count = first_length & 0x7F
+        if length_bytes_count == 0 or offset + length_bytes_count > len(der_bytes):
+            raise ValueError("invalid DER: bad long-form length")
+        length = int.from_bytes(der_bytes[offset:offset + length_bytes_count], "big")
+        offset += length_bytes_count
+    else:
+        length = first_length
+    if offset + length > len(der_bytes):
+        raise ValueError("invalid DER: value out of bounds")
+    value = der_bytes[offset:offset + length]
+    return tag, value, offset + length
+
+
+def _decode_rsa_public_key(public_key_b64: str):
+    spki_der = b64decode(public_key_b64)
+    seq_tag, spki_seq, seq_end = _read_der_tlv(spki_der, 0)
+    if seq_tag != 0x30 or seq_end != len(spki_der):
+        raise ValueError("invalid SubjectPublicKeyInfo structure")
+
+    _, _, cursor = _read_der_tlv(spki_seq, 0)
+    bit_string_tag, bit_string_value, cursor = _read_der_tlv(spki_seq, cursor)
+    if bit_string_tag != 0x03 or not bit_string_value or bit_string_value[0] != 0:
+        raise ValueError("invalid SubjectPublicKeyInfo BIT STRING")
+    if cursor != len(spki_seq):
+        raise ValueError("invalid SubjectPublicKeyInfo trailing bytes")
+
+    rsa_der = bit_string_value[1:]
+    rsa_seq_tag, rsa_seq, rsa_end = _read_der_tlv(rsa_der, 0)
+    if rsa_seq_tag != 0x30 or rsa_end != len(rsa_der):
+        raise ValueError("invalid RSAPublicKey structure")
+    modulus_tag, modulus_bytes, cursor = _read_der_tlv(rsa_seq, 0)
+    exponent_tag, exponent_bytes, cursor = _read_der_tlv(rsa_seq, cursor)
+    if modulus_tag != 0x02 or exponent_tag != 0x02 or cursor != len(rsa_seq):
+        raise ValueError("invalid RSAPublicKey fields")
+
+    modulus = int.from_bytes(modulus_bytes, "big")
+    exponent = int.from_bytes(exponent_bytes, "big")
+    key_bytes = len(modulus_bytes) - 1 if modulus_bytes.startswith(b"\x00") else len(modulus_bytes)
+    return modulus, exponent, key_bytes
+
+
+def rsa_encrypt_username_password(username: str, password: str, public_key_b64: str) -> str:
+    modulus, exponent, key_bytes = _decode_rsa_public_key(public_key_b64)
+    plaintext = (username + password).encode("utf-8")
+    max_plaintext_len = key_bytes - RSA_PADDING_OVERHEAD
+    if len(plaintext) > max_plaintext_len:
+        raise ValueError("username+password is too long for RSA key size")
+
+    padding_len = key_bytes - len(plaintext) - 3
+    padding = b""
+    while len(padding) < padding_len:
+        block = token_bytes(padding_len - len(padding))
+        padding += block.replace(b"\x00", b"")
+    encoded_message = b"\x00\x02" + padding[:padding_len] + b"\x00" + plaintext
+    cipher_int = pow(int.from_bytes(encoded_message, "big"), exponent, modulus)
+    return b64encode(cipher_int.to_bytes(key_bytes, "big")).decode("ascii")

--- a/ipgw/core/prepare_session.py
+++ b/ipgw/core/prepare_session.py
@@ -12,10 +12,22 @@
 # Cache-Control: no-cache
 from requests import Session
 
+DEFAULT_REQUEST_TIMEOUT = 3
+
+
+class TimeoutSession(Session):
+    def __init__(self, default_timeout: int = DEFAULT_REQUEST_TIMEOUT):
+        super().__init__()
+        self.default_timeout = default_timeout
+
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", self.default_timeout)
+        return super().request(method, url, **kwargs)
+
 
 # 加入bypass_proxy为参数，判断是否需要跳过系统代理，默认为false
 def prepare_session(bypass_proxy: bool = False) -> Session:
-    sess = Session()
+    sess = TimeoutSession()
     sess.headers.update({
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0",
         "Accept": "application/json",


### PR DESCRIPTION
## 背景
NEU 统一认证登录页更新后，原有 `rsa=username+password+lt` 提交方式会触发“请求出错”页面，导致 `ipgw i` 登录异常。  
同时，现有网络请求未设置超时，网络异常时 CLI 可能长时间无响应。

## 改动内容
1. 适配新的 RSA 加密流程 (ipgw/core/api/SSO.py, ipgw/core/api/sso_rsa.py)
- 新增 sso_rsa.py 模块，实现 PKCS#1 v1.5 RSA 加密
- 从 login_neu.js 动态提取 RSA 公钥
- 保持其余表单字段和原有登录流程不变。

2. 设置请求超时 (ipgw/core/prepare_session.py)
- 新增 TimeoutSession 类，继承自 requests.Session。
- 为所有 HTTP 请求统一设置默认超时 timeout=3s

## 验证
1. 本地编译检查通过：`pip install .`
2. 实测 `ipgw i` 可正常登录并返回状态信息。
3. 已测试有线和无线网络均可正常工作